### PR TITLE
Adjust properties of bank to use lists rather than sets for simplicity

### DIFF
--- a/bank_api/bank.py
+++ b/bank_api/bank.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Set
+from typing import Set, List
 
 
 @dataclass(frozen=True)
@@ -21,14 +21,14 @@ class Bank:
         self._transactions: Set[Transaction] = set()
 
     @property
-    def accounts(self) -> Set[Account]:
+    def accounts(self) -> List[Account]:
         """Get a copy of the bank's accounts"""
-        return self._accounts.copy()
+        return list(self._accounts)
 
     @property
-    def transactions(self) -> Set[Transaction]:
+    def transactions(self) -> List[Transaction]:
         """Get a copy of the bank's transactions"""
-        return self._transactions.copy()
+        return list(self._transactions)
 
     def create_account(self, name: str) -> Account:
         """Creates a new account with the name provided"""

--- a/tests/test_bank.py
+++ b/tests/test_bank.py
@@ -39,7 +39,7 @@ def test_cannot_duplicate_accounts(bank):
 
 def test_cannot_modify_accounts_set(bank):
     accounts = bank.accounts
-    accounts.add(Account('New Account'))
+    accounts.append(Account('New Account'))
 
     assert len(bank.accounts) == 0
 


### PR DESCRIPTION
Just a small change to swap to using lists in the properties, to remove that overhead - quite a few learners seem to stumble here and I'm not convinced the learning point is worth it. Also planning to make some simple tweaks to the workshop slides as well to give a bit longer for this exercise